### PR TITLE
Trim path for jdownloader incase the path length is more than 255

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/jd_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/jd_download.py
@@ -98,6 +98,17 @@ async def get_online_packages(path, state="grabbing"):
         return [dl["uuid"] for dl in download_packages if dl["saveTo"].startswith(path)]
 
 
+def trim_path(path):
+    path_components = path.split("/")
+
+    trimmed_components = [
+        component[:255] if len(component) > 255 else component
+        for component in path_components
+    ]
+
+    return "/".join(trimmed_components)
+
+
 async def add_jd_download(listener, path):
     try:
         async with jd_lock:
@@ -196,6 +207,7 @@ async def add_jd_download(listener, path):
                             )[0]
                         else:
                             name = save_to.replace(f"{path}/", "", 1).split("/", 1)[0]
+                        name = name[:255]
 
                     if (
                         pack.get("tempUnknownCount", 0) > 0
@@ -207,6 +219,7 @@ async def add_jd_download(listener, path):
                     listener.size += pack.get("bytesTotal", 0)
                     online_packages.append(pack["uuid"])
                     if save_to.startswith("/root/Downloads/"):
+                        save_to = trim_path(save_to)
                         await retry_function(
                             jdownloader.device.linkgrabber.set_download_directory,
                             save_to.replace("/root/Downloads", path, 1),


### PR DESCRIPTION
- Incase you got file error invalid downlaod path then you must rename the file(s)

I have done the folder rename auto for you but i don't want to fetch all files names, this  will take a lot of time